### PR TITLE
Tiny change to the README.md file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ $myRouter->addRoute(Route::newFromUriTemplate('/things/', 'ThingCollectionHandle
 $myRouter->addRoute(Route::newFromUriTemplate('/things/{id}', 'ThingItemHandler'));
 
 // Determine and output the response.
-$response = $router->getResponse();
+$response = $myRouter->getResponse();
 $response->respond();
 ```
 


### PR DESCRIPTION
There seemed to be a discrepancy with the local variables in the Routing section of the README. At the top of the code fragment, you initiate an object named $myRouter. Below that, you refer to an object named $router. I think they reference the same object, so I forked the project and made the change.
