### PR TITLE
Update uri-templates-advanced.rst

### DIFF
--- a/docs/source/uri-templates-advanced.rst
+++ b/docs/source/uri-templates-advanced.rst
@@ -37,7 +37,7 @@ You may also use the explode (``*``) modifier to match a variable number of path
     *   - {/path*}
         - /any/number/of/parts.jpg
         - Yes
-        - :path: ``["any", "number", "of", "parts"]``
+        - :path: ``["any", "number", "of", "parts.jpg"]``
     *   - /image{/image*}.jpg
         - /image/with/any/path.jpg
         - Yes


### PR DESCRIPTION
This may or may not be correct... I believe that the {/path*} template, when used to mach /any/number/of/parts.jpg, will return :path = ["any", "number", "of", "parts.jpg"]. The only change here is the addition of the .jpg after parts. If this is incorrect, please disregard.