### PR TITLE
Server Updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2
@@ -59,7 +59,7 @@ jobs:
           - "8.1"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install PHP with extensions
         uses: shivammathur/setup-php@v2

--- a/README.md
+++ b/README.md
@@ -128,5 +128,5 @@ The runs a site you can access at [http://localhost:8080](http://localhost:8080)
 
 Copyright and License
 ---------------------
-Copyright © 2022 by PJ Dietz
+Copyright © 2024 by PJ Dietz
 Licensed under the [MIT license](http://opensource.org/licenses/MIT)

--- a/src/Server.php
+++ b/src/Server.php
@@ -63,14 +63,18 @@ class Server implements RequestHandlerInterface
         return $this->middlewareQueue->getMiddleware();
     }
 
-    /**
-     * Return a new Router that uses the server's configuration.
-     *
-     * @return Router
-     */
+    /** Return a new Router that uses the server's configuration. */
     public function createRouter(): Router
     {
         $router = new Router($this);
+        return $router;
+    }
+
+    /** Return a new Router and add it to the Server's middleware queue */
+    public function addRouter(): Router
+    {
+        $router = $this->createRouter();
+        $this->add($router);
         return $router;
     }
 

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -147,7 +147,7 @@ class ServerTest extends TestCase
         $this->server->setDispatcher($dispatcher->reveal());
 
         // Create a new router that should get the custom dispatcher.
-        $router = $this->server->createRouter();
+        $router = $this->server->addRouter();
         $router->register('GET', '/', 'middleware');
 
         // Act


### PR DESCRIPTION
Adds a couple methods to `Server`

- `handle()` is mainly for internal use. This was added to make it easier to instrument with OpenTelemetry.
- `addRouter()` is a new convenience method that adds the new `Router` to the server upon creation.